### PR TITLE
Update navigation order: Experience before Projects

### DIFF
--- a/CV.html
+++ b/CV.html
@@ -17,8 +17,8 @@
             <a href="index.html" class="logo">Johnny Yu</a>
             <ul class="nav-links">
                 <li><a href="index.html">Home</a></li>
-                <li><a href="projects.html">Projects</a></li>
                 <li><a href="experience.html">Experience</a></li>
+                <li><a href="projects.html">Projects</a></li>
                 <li><a href="CV.html" class="active">Resume</a></li>
             </ul>
             <div class="social-links">

--- a/experience.html
+++ b/experience.html
@@ -17,8 +17,8 @@
             <a href="index.html" class="logo">Johnny Yu</a>
             <ul class="nav-links">
                 <li><a href="index.html">Home</a></li>
-                <li><a href="projects.html">Projects</a></li>
                 <li><a href="experience.html" class="active">Experience</a></li>
+                <li><a href="projects.html">Projects</a></li>
                 <li><a href="CV.html">Resume</a></li>
             </ul>
             <div class="social-links">

--- a/index.html
+++ b/index.html
@@ -20,8 +20,8 @@
             <a href="index.html" class="logo">Johnny Yu</a>
             <ul class="nav-links">
                 <li><a href="index.html" class="active">Home</a></li>
-                <li><a href="projects.html">Projects</a></li>
                 <li><a href="experience.html">Experience</a></li>
+                <li><a href="projects.html">Projects</a></li>
                 <li><a href="CV.html">Resume</a></li>
             </ul>
             <div class="social-links">

--- a/projects.html
+++ b/projects.html
@@ -17,8 +17,8 @@
             <a href="index.html" class="logo">Johnny Yu</a>
             <ul class="nav-links">
                 <li><a href="index.html">Home</a></li>
-                <li><a href="projects.html" class="active">Projects</a></li>
                 <li><a href="experience.html">Experience</a></li>
+                <li><a href="projects.html" class="active">Projects</a></li>
                 <li><a href="CV.html">Resume</a></li>
             </ul>
             <div class="social-links">


### PR DESCRIPTION
Reordered the main navigation links in the header across all HTML pages (index.html, experience.html, projects.html, CV.html) to place the 'Experience' tab before the 'Projects' tab.

This change reflects the typical importance of work experience for recruiters viewing the portfolio.